### PR TITLE
Identity cleanup

### DIFF
--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -258,7 +258,7 @@ all clients registered in the application. However, if domains are being used
 then client handles are only unique within scope of the client's domain.
 
 If the Provider is configured to use accounts then a client handle is defined
-to be the concatenation of its account handel followed by its end point handle
+to be the concatenation of its account handle followed by its end point handle
 seperated by a "/". When accounts are not used the client handle is simply its
 end point handle.
 

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -253,9 +253,10 @@ If (params.use_domains == true) && (params.use_accounts == true) {
 ### X.509 Identifiers
 
 Each client has a handle (i.e. a human readable name). If the X509 Identity
-Provider is configured to not use domains then client handles are unique across
-all clients registered in the application. However, if domains are being used
-then client handles are only unique within scope of the client's domain.
+Provider is configured to not use domains then client handles MUST be unique
+across all clients registered in the application. However, if domains are being
+used then client handles MUST only be unique within scope of the client's
+domain.
 
 If the Provider is configured to use accounts then a client handle is defined
 to be the concatenation of its account handle followed by its end point handle

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -173,10 +173,10 @@ provider. It has the following properties:
 ## X.509 Identity Provider
 
 The X.509 identify provider allows for hierarchical identities based on
-certificate chains. The provider is configured via the `X509Paremter` struct. 
-Besides just clients, depending on the configuration the provider may also
-support accounts and/or domains. Conceptually, an account is a collection of
-clients (usually belonging to one user) and a domain is a collection of accounts
+certificate chains. The provider is configured via the `X509Parameters` struct. 
+Besides clients, depending on how the provider is configured it may also support
+accounts and/or domains. Conceptually, an account is a collection of clients
+(usually belonging to one user) and a domain is a collection of accounts
 (e.g. belonging to a particular organization).
 
 The only credential supported by the X509 Identity Provider are `x509` 
@@ -283,21 +283,21 @@ Name fields of a range of certificates in client's certificate chain credential.
 The range to use is defined by the `start` and `end` offsets in the 
 `endpoint_handle_range` field of the `X509Parameters` struct. Offsets begin at
 the leaf certificate wich has offset 0 and count upwards towards the root
-certificate in the chain. Each Common Name field in the range is seperated in
-the client handle from the previous one with a ":" delimiter.
+certificate in the chain. Each Common Name field in the range is seperated from
+the next in the client handle using a ":" character as delimiter.
 
 ### X.509 Account Handles
 
-When X509 Identity Provider is configured to use accounts a client's account
+When the X509 Identity Provider is configured to use accounts a client's account
 handle is calculated just like its end point handle but using only the
-certificate with the offset given in the `account_handle_offset` field in the
+certificate with the offset given by the `account_handle_offset` field in the
 `X509Parameters` struct.
 
 ### X.509 Domains Names
 
-When X509 Identity Provider is configured to use domains a client's domain name
-is calculated just like its end point handle but using only the certificate with
-the offset given in the `domain_name_offset` field in the `X509Parameters`
+When the X509 Identity Provider is configured to use domains a client's domain
+name is calculated just like its end point handle but using only the certificate
+with the offset given in the `domain_name_offset` field in the `X509Parameters`
 struct.
 
 ### Handing Timestamps 
@@ -350,9 +350,9 @@ represents attributes associated with the client, for example:
 
 Tags of a given client are provided by the application. The service
 allows the application to search for clients by tags. For example,
-searching by tag 1. above allows to list all clients owned by
+searching by the above tag 1. allows listing all clients owned by
 `alice@org`, which is a typical scenario in messaging applications where
-Bob invites a multi-device account of Alice to join a chat. Searching by a tag 
+Bob invites a multi-device account of Alice to join a chat. Searching by the tag 
 2. above allows to add an arbitrary moderator, or all clients owned by
 entities with the right clearance.
 
@@ -380,8 +380,8 @@ Output:
 ~~~
 
 In the above figure, the returned `clientId` is the new identifier assigned to
-the client by the identity service. Services MUST ensure that `clientId` is
-unique amongst all registered clients. 
+the client by the identity service. Services MUST ensure that `clientId` and
+`clientHandle` are both unique among all registered clients. 
 
 A client MAY be editable by the following request:
 

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -179,7 +179,7 @@ accounts and/or domains. Conceptually, an account is a collection of clients
 (usually belonging to one user) and a domain is a collection of accounts
 (e.g. belonging to a particular organization).
 
-The only credential supported by the X509 Identity Provider are `x509` 
+The only credential type supported by the X509 Identity Provider is `x509` .
 credentials which consist of a chain of 1 or more X.509 certificates. 
 Certificate chains MUST be validated according to the rules in RFC 5280 using
 the trust roots agreed upon by the (TODO: Some sort of extension dealing with

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -181,7 +181,7 @@ accounts and/or domains. Conceptually, an account is a collection of clients
 
 The only credential type supported by the X509 Identity Provider is `x509` .
 credentials which consist of a chain of 1 or more X.509 certificates. 
-Certificate chains MUST be validated according to the rules in RFC 5280 using
+Certificate chains MUST be validated according to the rules in {{!RFC5280}} using
 the trust roots agreed upon by the (TODO: Some sort of extension dealing with
 trust root negotiation).
 

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -271,7 +271,7 @@ If (params.use_accounts == true) {
 ~~~
 
 End piont handles, account handles (when used) and domain names (when used) are
-derived from subject Common Name fields in a clients credential certificate
+derived from subject Common Name fields in a client's credential certificate
 chain as described bellow. To ensure unambiguous URI's for clients and accounts
 (as described in {{?I-D.draft-mahy-mimi-identity}}) the Common Name fields found
 used to derive the handles MUST NOT contain any of the 5 special characters

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -274,7 +274,7 @@ End piont handles, account handles (when used) and domain names (when used) are
 derived from subject Common Name fields in a clients credential certificate
 chain as described bellow. To ensure unambiguous URI's for clients and accounts
 (as described in {{?I-D.draft-mahy-mimi-identity}}) the Common Name fields found
-used to derive the handles MUST not contain any of the 5 special characters
+used to derive the handles MUST NOT contain any of the 5 special characters
 "@", "/", "#", "$" and ":". 
 
 ### X.509 End Point Handles

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -240,7 +240,7 @@ from the leaf certificate up.
 If (params.user_domains == true) {
     Assert (params.domain_name_offset > params.endpoint_handle_range.end)
 }
-~~~~
+~~~
 
 Finally, if both domains and accounts are used then the domain name offset MUST
 also strictly succeed the account handle offset.

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -196,21 +196,21 @@ struct {
 } X509EndpointHandleRange
 
 struct {
-	bool use_accounts;
-	bool use_domains:
+    bool use_accounts;
+    bool use_domains:
     X509EndpointHandleRange endpoint_handle_range;
-	select (use_accounts) {
-	    case true:
-		    uint8 account_handle_offset;
-		case false:
-		    struct {}
-	}
-	select (use_domains) {
-	    case true:
-		    uint8 domain_name_offset;
-		case false:
-		    struct {}
-	}
+    select (use_accounts) {
+        case true:
+            uint8 account_handle_offset;
+        case false:
+            struct {}
+    }
+    select (use_domains) {
+        case true:
+            uint8 domain_name_offset;
+        case false:
+            struct {}
+    }
 } X509Parameters;
 ~~~
 

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -180,7 +180,7 @@ accounts and/or domains. Conceptually, an account is a collection of clients
 (e.g. belonging to a particular organization).
 
 The only credential type supported by the X509 Identity Provider is `x509` .
-credentials which consist of a chain of 1 or more X.509 certificates. 
+An X.509 credential contains a chain of 1 or more X.509 certificates, encoded as specified in {{!I-D.ietf-mls-protocol}}.
 Certificate chains MUST be validated according to the rules in {{!RFC5280}} using
 the trust roots agreed upon by the (TODO: Some sort of extension dealing with
 trust root negotiation).

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -193,12 +193,12 @@ struct {
 struct {
     uint8 start;
     uint8 end<0...255>;
-} X509EndpointHandleRange
+} X509DeviceHandleRange
 
 struct {
     bool use_accounts;
     bool use_domains:
-    X509EndpointHandleRange endpoint_handle_range;
+    X509DeviceHandleRange device_handle_range;
     select (use_accounts) {
         case true:
             uint8 account_handle_offset;
@@ -215,30 +215,30 @@ struct {
 ~~~
 
 A given parameter set `X509Parameters params` is valid if the following
-conditions are all met. The end point handle range MUST not end before it
+conditions are all met. The device handle range MUST not end before it
 starts.
 
 ~~~
-Assert (params.endpoint_handle_range.end >= params.endpoint_handle_range.start)
+Assert (params.device_handle_range.end >= params.device_handle_range.start)
 ~~~
 
 If the X509 Identity Provider is configured to use accounts then the account
-handel offset MUST strictly succeed the end point handle range in the
+handel offset MUST strictly succeed the device handle range in the
 certificate chain counting from the leaf certificate up. 
 
 ~~~
 If (params.use_accounts == true) {
-    Assert (params.account_handle_offset > params.endpoint_handle_range.end)
+    Assert (params.account_handle_offset > params.device_handle_range.end)
 }
 ~~~~
 
 If the provider is configured to use domains then the domain name offset MUST
-strictly succeeds the end point handle range in the certificate chain counting
+strictly succeeds the device handle range in the certificate chain counting
 from the leaf certificate up.
 
 ~~~
 If (params.user_domains == true) {
-    Assert (params.domain_name_offset > params.endpoint_handle_range.end)
+    Assert (params.domain_name_offset > params.device_handle_range.end)
 }
 ~~~
 
@@ -259,15 +259,15 @@ used then client handles MUST only be unique within scope of the client's
 domain.
 
 If the Provider is configured to use accounts then a client handle is defined
-to be the concatenation of its account handle followed by its end point handle
+to be the concatenation of its account handle followed by its device handle
 seperated by a "/". When accounts are not used the client handle is simply its
-end point handle.
+device handle.
 
 ~~~
 If (params.use_accounts == true) {
-    client_handle := account_handle + "/" + end_point_handle;
+    client_handle := account_handle + "/" + device_handle;
 } Else {
-    client_handle := end_point_handle;
+    client_handle := device_handle;
 }
 ~~~
 
@@ -278,11 +278,11 @@ chain as described bellow. To ensure unambiguous URI's for clients and accounts
 used to derive the handles MUST NOT contain any of the 5 special characters
 "@", "/", "#", "$" and ":". 
 
-### X.509 End Point Handles
-A client's end point handle is derived by concatenating the X.509 subject Common
+### X.509 Device Handles
+A client's device handle is derived by concatenating the X.509 subject Common
 Name fields of a range of certificates in client's certificate chain credential.
 The range to use is defined by the `start` and `end` offsets in the 
-`endpoint_handle_range` field of the `X509Parameters` struct. Offsets begin at
+`device_handle_range` field of the `X509Parameters` struct. Offsets begin at
 the leaf certificate wich has offset 0 and count upwards towards the root
 certificate in the chain. Each Common Name field in the range is seperated from
 the next in the client handle using a ":" character as delimiter.
@@ -290,14 +290,14 @@ the next in the client handle using a ":" character as delimiter.
 ### X.509 Account Handles
 
 When the X509 Identity Provider is configured to use accounts a client's account
-handle is calculated just like its end point handle but using only the
+handle is calculated just like its device handle but using only the
 certificate with the offset given by the `account_handle_offset` field in the
 `X509Parameters` struct.
 
 ### X.509 Domains Names
 
 When the X509 Identity Provider is configured to use domains a client's domain
-name is calculated just like its end point handle but using only the certificate
+name is calculated just like its device handle but using only the certificate
 with the offset given in the `domain_name_offset` field in the `X509Parameters`
 struct.
 

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -146,7 +146,7 @@ interface {
 ~~~
 
 Each identity provider has a unique value that identifies its behavior along
-with opaque parameters that help synchronize various options across
+with opaque parameters which help synchronize various options across
 applications. 
 
 ~~~
@@ -157,6 +157,8 @@ struct {
     opaque parameters<V>;
 } IdentityConfiguration;
 ~~~
+
+The rest of this section describes two examples of Identity Providers.
 
 ## Basic Identity Provider 
 
@@ -170,127 +172,133 @@ provider. It has the following properties:
 
 ## X.509 Identity Provider
 
-The X.509 identify provider allows for a hierarchical identity that is based
-upon a certificate chain. x509 is the only credential type supported.
+The X.509 identify provider allows for hierarchical identities based on
+certificate chains. The provider is configured via the `X509Paremter` struct. 
+Besides just clients, depending on the configuration the provider may also
+support accounts and/or domains. Conceptually, an account is a collection of
+clients (usually belonging to one user) and a domain is a collection of accounts
+(e.g. belonging to a particular organization).
+
+The only credential supported by the X509 Identity Provider are `x509` 
+credentials which consist of a chain of 1 or more X.509 certificates. 
 Certificate chains MUST be validated according to the rules in RFC 5280 using
 the trust roots agreed upon by the (TODO: Some sort of extension dealing with
 trust root negotiation).
 
 ~~~
 struct {
-   uint64 msg_timestamp;
+    uint64 msg_timestamp;
 } X509ApplicationContext;
 
 struct {
-    X509IdentityRange range;
+    uint8 start;
+    uint8 end<0...255>;
+} X509EndpointHandleRange
+
+struct {
+	bool use_accounts;
+	bool use_domains:
+    X509EndpointHandleRange endpoint_handle_range;
+	select (use_accounts) {
+	    case true:
+		    uint8 account_handle_offset;
+		case false:
+		    struct {}
+	}
+	select (use_domains) {
+	    case true:
+		    uint8 domain_name_offset;
+		case false:
+		    struct {}
+	}
 } X509Parameters;
 ~~~
 
+A given parameter set `X509Parameters params` is valid if the following
+conditions are all met. The end point handle range MUST not end before it
+starts.
+
+~~~
+Assert (params.endpoint_handle_range.end >= params.endpoint_handle_range.start)
+~~~
+
+If the X509 Identity Provider is configured to use accounts then the account
+handel offset MUST strictly succeeds the end point handle range in the
+certificate chain counting from the leaf certificate up. 
+
+~~~
+If (params.use_accounts == true) {
+    Assert (params.account_handle_offset > params.endpoint_handle_range.end)
+}
+~~~~
+
+If the provider is configured to use domains then the domain name offset MUST
+strictly succeeds the end point handle range in the certificate chain counting
+from the leaf certificate up.
+
+~~~
+If (params.user_domains == true) {
+    Assert (params.domain_name_offset > params.endpoint_handle_range.end)
+}
+~~~~
+
+Finally, if both domains and accounts are used then the domain name offset MUST
+also strictly succeed the account handle offset.
+
+~~~
+If (params.use_domains == true) && (params.use_accounts == true) {
+    Assert (params.domain_name_offset > params.account_handle_offset)
+~~~~
+
 ### X.509 Identifiers
 
-Identifiers (e.g. handles for clients) are derived by iterating through a subset
-of X.509 subject Common Name fields found within the client's certificate chain.
-Common Name fields MUST not contain any of the 5 special characters "@", "/",
-"#", "$" and ":". The range of certificates in the chain to used in the
-derivation is defined as starting with `start` values from the leaf and ending
-with `end` values from the leaf.
+Each client has a handle (i.e. a human readable name). If the X509 Identity
+Provider is configured to not use domains then client handles are unique across
+all clients registered in the application. However, if domains are being used
+then client handles are only unique within scope of the client's domain.
+
+If the Provider is configured to use accounts then a client handle is defined
+to be the concatenation of its account handel followed by its end point handle
+seperated by a "/". When accounts are not used the client handle is simply its
+end point handle.
 
 ~~~
-fn identifier(CertificateChain cert_chain, uint8 start, uint8 end) {
-    string id = new String;
-    bool first = true;
-    
-    for certificate in cert_chain[start...end] {
-        let common_name = certificate.subject.common_name;
-
-        if (!common_name) {
-            throw "Common name is required";
-        }
-        
-        if (common_name.contains("@","/","#","$",":") {
-            throw "Common names may not contain @/#$: characters.";
-        }
-
-        if (!first) {
-            id.append(":");
-        } else {
-            first = false;
-        }
-        id.append(common_name);
-    }
-
-    return id;
+If (params.use_accounts == true) {
+    client_handle := account_handle + "/" + end_point_handle;
+} Else {
+    client_handle := end_point_handle;
 }
 ~~~
 
-### X.509 Client Handles
-A client handle is a human readable name for a client.
-{{?I-D.draft-mahy-mimi-identity}} The X.509 identity provider extracts the
-client handle from a client's credentials by fixing a range and calling
-'identifier' for the certificates in the range.
+End piont handles, account handles (when used) and domain names (when used) are
+derived from subject Common Name fields in a clients credential certificate
+chain as described bellow. To ensure unambiguous URI's for clients and accounts
+(as described in {{?I-D.draft-mahy-mimi-identity}}) the Common Name fields found
+used to derive the handles MUST not contain any of the 5 special characters
+"@", "/", "#", "$" and ":". 
 
-~~~
-struct {
-    uint8 start;
-    uint8 end<0...255>;
-} X509ClientHandleRange
+### X.509 End Point Handles
+A client's end point handle is derived by concatenating the X.509 subject Common
+Name fields of a range of certificates in client's certificate chain credential.
+The range to use is defined by the `start` and `end` offsets in the 
+`endpoint_handle_range` field of the `X509Parameters` struct. Offsets begin at
+the leaf certificate wich has offset 0 and count upwards towards the root
+certificate in the chain. Each Common Name field in the range is seperated in
+the client handle from the previous one with a ":" delimiter.
 
-fn client_handle(CertificateChain cert_chain, X509ClientHandleRange range) {
-    return identifier(cert_chain, range.start, range.end)
-}
-~~~
+### X.509 Account Handles
 
-### X.509 Account Identifiers
-
-Many messaging systems use multi-client (e.g. multi-device) accounts.
-Accounts are also refered to as users {{?I-D.draft-mahy-mimi-identity}}. Account
-handles are calculated like client handles but based on the certificate
-at the Account Handle offset (instead of Client Handle range).
-
-~~~
-uint8 X509AcntHandleOffset;
-
-fn acount_identifier(CertificateChain cert_chain, X509AcntHandleOffset offset) {
-    return identifier(cert_chain, offset, offset)
-}
-~~~
-
-The Account Handle offset strictly succeeds the Client Handle range in the
-certificate chain counting from the leaf certificate up.
-
-~~~
-X509AcntHandleOffset > X509ClientHandleRange.end
-~~~~
+When X509 Identity Provider is configured to use accounts a client's account
+handle is calculated just like its end point handle but using only the
+certificate with the offset given in the `account_handle_offset` field in the
+`X509Parameters` struct.
 
 ### X.509 Domains Names
 
-Federated messaging systems often associate accounts with a domain (e.g. that of
-a home server hosting the account). Domain Names are calculated just like
-Account Handles but using the Domain Name offset in place of the Account
-Handle offset.
-
-~~~
-uint8 X509DomainNameOffset;
-
-fn domain_identifier(CertificateChain cert_chain, X509DomainNameOffset offset) {
-    return identifier(cert_chain, offset, offset)
-}
-~~~
-
-The Domain Name offset strictly succeeds the Client Handle range in the
-certificate chain counting from the leaf certificate up.
-
-~~~
-X509DomainIDOffset > X509ClientHandleRange.end
-~~~~
-
-When Account identifiers are used then the Domain Name offset must also
-strictly succeed the Account Handle offset.
-
-~~~
-X509DomainIDOffset > X509AccountIDRange.end
-~~~~
-
+When X509 Identity Provider is configured to use domains a client's domain name
+is calculated just like its end point handle but using only the certificate with
+the offset given in the `domain_name_offset` field in the `X509Parameters`
+struct.
 
 ### Handing Timestamps 
 

--- a/draft-aegis-mimi-arch-latest.md
+++ b/draft-aegis-mimi-arch-latest.md
@@ -223,7 +223,7 @@ Assert (params.endpoint_handle_range.end >= params.endpoint_handle_range.start)
 ~~~
 
 If the X509 Identity Provider is configured to use accounts then the account
-handel offset MUST strictly succeeds the end point handle range in the
+handel offset MUST strictly succeed the end point handle range in the
 certificate chain counting from the leaf certificate up. 
 
 ~~~


### PR DESCRIPTION
Implemented the following changes:
- Make IDRange consistent
- Replace code in handle computation with text
- ClientHandle w & w/o Accounts. Domain's just seperate
- move x509acntHandelRange into X509Parameters def.
 = move the range checks to X509Param validation section.
- Same for X509DomainHandelRange

ToDo still of things we discussed:
- Make application be its own section
